### PR TITLE
improv/can-remove-files-extensions-from-po-files

### DIFF
--- a/lib/jsxgettext.js
+++ b/lib/jsxgettext.js
@@ -187,7 +187,8 @@ function parse(sources, options) {
 
         var line = node.loc.start.line;
         var comments = findComments(astComments, line);
-        var ref = filename + ':' + line;
+        var newFilename = options.removeFilesExtensions ? filename.split('.').slice(0, -1).join('.') : filename;
+        var ref = newFilename + ':' + line;
         if (!translations[msgid + msgctxt]) {
           translations[msgid + msgctxt] = {
             msgid: msgid,


### PR DESCRIPTION
usecase example :
generate less diff when migrating `jsx` -> `tsx` file